### PR TITLE
Earlier "ignore items" rules overwritten by later ones

### DIFF
--- a/ElvUI/modules/bags/sort.lua
+++ b/ElvUI/modules/bags/sort.lua
@@ -563,7 +563,7 @@ function B.Sort(bags, sorter, invertDirection)
 				for _,itemsearchquery in pairs(blackListQueries) do
 					local success, result = pcall(Search.Matches, Search, link, itemsearchquery);
 					if(success) then
-						blackListedSlots[bagSlot] = result;
+						blackListedSlots[bagSlot] = blackListedSlots[bagSlot] or result;
 					end
 				end
 			end


### PR DESCRIPTION
When there are multiple `blackListQueries` that affect the same `bagSlot`, only the result of the **_last_ query** is considered.

This change makes it so the slot is considered blacklisted if it matches **_any_** of the queries.